### PR TITLE
Make tapestry compatible with Hibernate 5 (TAP5-2525)

### DIFF
--- a/tapestry-hibernate/src/main/java/org/apache/tapestry5/hibernate/modules/HibernateModule.java
+++ b/tapestry-hibernate/src/main/java/org/apache/tapestry5/hibernate/modules/HibernateModule.java
@@ -42,7 +42,6 @@ import org.apache.tapestry5.services.dashboard.DashboardManager;
 import org.apache.tapestry5.services.dashboard.DashboardTab;
 import org.apache.tapestry5.services.transform.ComponentClassTransformWorker2;
 import org.hibernate.Session;
-import org.hibernate.mapping.PersistentClass;
 
 import java.util.Iterator;
 
@@ -91,12 +90,9 @@ public class HibernateModule
         if (!provideEncoders)
             return;
 
-        org.hibernate.cfg.Configuration config = sessionSource.getConfiguration();
-        Iterator<PersistentClass> mappings = config.getClassMappings();
-        while (mappings.hasNext())
+        for (ClassMetadata classMetadata : sessionSource.getSessionFactory().getAllClassMetadata().values())
         {
-            final PersistentClass persistentClass = mappings.next();
-            final Class entityClass = persistentClass.getMappedClass();
+            final Class entityClass = classMetadata.getMappedClass();
 
             if (entityClass != null)
             {
@@ -105,7 +101,7 @@ public class HibernateModule
                     @Override
                     public ValueEncoder create(Class type)
                     {
-                        return new HibernateEntityValueEncoder(entityClass, persistentClass, session, propertyAccess,
+                        return new HibernateEntityValueEncoder(entityClass, classMetadata.getIdentifierPropertyName(), session, propertyAccess,
                                 typeCoercer, loggerSource.getLogger(entityClass));
                     }
                 };
@@ -161,15 +157,10 @@ public class HibernateModule
 
         if (!entitySessionStatePersistenceStrategyEnabled)
             return;
-
-        org.hibernate.cfg.Configuration config = sessionSource.getConfiguration();
-        Iterator<PersistentClass> mappings = config.getClassMappings();
-        while (mappings.hasNext())
+    
+        for (ClassMetadata classMetadata : sessionSource.getSessionFactory().getAllClassMetadata().values())
         {
-
-            final PersistentClass persistentClass = mappings.next();
-            final Class entityClass = persistentClass.getMappedClass();
-
+            final Class entityClass = classMetadata.getMappedClass();
             configuration.add(entityClass, new ApplicationStateContribution(HibernatePersistenceConstants.ENTITY));
         }
     }

--- a/tapestry-hibernate/src/main/java/org/apache/tapestry5/internal/hibernate/HibernateEntityValueEncoder.java
+++ b/tapestry-hibernate/src/main/java/org/apache/tapestry5/internal/hibernate/HibernateEntityValueEncoder.java
@@ -21,7 +21,6 @@ import org.apache.tapestry5.ioc.services.PropertyAdapter;
 import org.apache.tapestry5.ioc.services.TypeCoercer;
 import org.apache.tapestry5.ioc.util.ExceptionUtils;
 import org.hibernate.Session;
-import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.slf4j.Logger;
 
@@ -39,7 +38,7 @@ public final class HibernateEntityValueEncoder<E> implements ValueEncoder<E>
 
     private final Logger logger;
 
-    public HibernateEntityValueEncoder(Class<E> entityClass, PersistentClass persistentClass, Session session,
+    public HibernateEntityValueEncoder(Class<E> entityClass, String identifierPropertyName, Session session,
                                        PropertyAccess propertyAccess, TypeCoercer typeCoercer, Logger logger)
     {
         this.entityClass = entityClass;
@@ -47,9 +46,7 @@ public final class HibernateEntityValueEncoder<E> implements ValueEncoder<E>
         this.typeCoercer = typeCoercer;
         this.logger = logger;
 
-        Property property = persistentClass.getIdentifierProperty();
-
-        propertyAdapter = propertyAccess.getAdapter(this.entityClass).getPropertyAdapter(property.getName());
+        propertyAdapter = propertyAccess.getAdapter(this.entityClass).getPropertyAdapter(identifierPropertyName);
     }
 
     @Override

--- a/tapestry-hibernate/src/test/java/org/apache/tapestry5/internal/hibernate/HibernateEntityValueEncoderTest.java
+++ b/tapestry-hibernate/src/test/java/org/apache/tapestry5/internal/hibernate/HibernateEntityValueEncoderTest.java
@@ -19,8 +19,6 @@ import org.apache.tapestry5.ioc.services.PropertyAccess;
 import org.apache.tapestry5.ioc.services.TypeCoercer;
 import org.apache.tapestry5.ioc.test.IOCTestCase;
 import org.hibernate.Session;
-import org.hibernate.mapping.Property;
-import org.hibernate.mapping.RootClass;
 import org.slf4j.Logger;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -59,14 +57,10 @@ public class HibernateEntityValueEncoderTest extends IOCTestCase
 
         replay();
 
-        RootClass persistentClass = new RootClass();
-        Property idProperty = new Property();
-        idProperty.setName("id");
-        persistentClass.setIdentifierProperty(idProperty);
         SampleEntity entity = new SampleEntity();
 
         HibernateEntityValueEncoder<SampleEntity> encoder = new HibernateEntityValueEncoder<SampleEntity>(
-                SampleEntity.class, persistentClass, session, access, typeCoercer, logger);
+                SampleEntity.class, "id", session, access, typeCoercer, logger);
 
         assertNull(encoder.toClient(entity));
 
@@ -85,14 +79,10 @@ public class HibernateEntityValueEncoderTest extends IOCTestCase
 
         replay();
 
-        RootClass persistentClass = new RootClass();
-        Property idProperty = new Property();
-        idProperty.setName("id");
-        persistentClass.setIdentifierProperty(idProperty);
         SampleEntity entity = new SampleEntity();
 
         HibernateEntityValueEncoder<SampleEntity> encoder = new HibernateEntityValueEncoder<SampleEntity>(
-                SampleEntity.class, persistentClass, session, access, typeCoercer, logger);
+                SampleEntity.class, "id", session, access, typeCoercer, logger);
 
         assertNull(encoder.toValue("12345"));
 
@@ -107,13 +97,8 @@ public class HibernateEntityValueEncoderTest extends IOCTestCase
 
         replay();
 
-        RootClass persistentClass = new RootClass();
-        Property idProperty = new Property();
-        idProperty.setName("id");
-        persistentClass.setIdentifierProperty(idProperty);
-
         HibernateEntityValueEncoder<SampleEntity> encoder = new HibernateEntityValueEncoder<SampleEntity>(
-                SampleEntity.class, persistentClass, session, access, typeCoercer, logger);
+                SampleEntity.class, "id", session, access, typeCoercer, logger);
 
         try
         {


### PR DESCRIPTION
Avoiding the use of the method `org.hibernate.cfg.Configuration.getClassMappings()`, which was removed in Hibernate version 5, while retaining backwards compatibility with Hibernate 3.x and 4.x.
