### PR TITLE
Remove unused import org.hibernate.cfg.AnnotationConfiguration

### DIFF
--- a/tapestry-hibernate-core/src/main/java/org/apache/tapestry5/internal/hibernate/PackageNameHibernateConfigurer.java
+++ b/tapestry-hibernate-core/src/main/java/org/apache/tapestry5/internal/hibernate/PackageNameHibernateConfigurer.java
@@ -17,7 +17,6 @@ package org.apache.tapestry5.internal.hibernate;
 import org.apache.tapestry5.hibernate.HibernateConfigurer;
 import org.apache.tapestry5.hibernate.HibernateEntityPackageManager;
 import org.apache.tapestry5.ioc.services.ClassNameLocator;
-import org.hibernate.cfg.AnnotationConfiguration;
 import org.hibernate.cfg.Configuration;
 
 /**


### PR DESCRIPTION
Greetings.
Tryed to use 5.4.1 with hibernate 5.1.0.

When tapestry tryed to close session it returns NoSuchMethodError:

`java.lang.NoSuchMethodError: org.hibernate.Session.close()Ljava/sql/Connection;`

So after i recompile tapestry-hibernate-core against hibernate 5.1 i found that this import 
1) not used. 
2) used removed AnnotationConfiguration from hibernate package. 

So, after recompile everything works as it should. 
