### PR TITLE
Tapestry 5.4 Service proxies erase generic parameter and return types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ project.version = tapestryVersion()
 def tapestryVersion() {
 
     def major = "5.4.1"
-    def minor = ""
+    def minor = ".1.sgo"
 
     // When building on the CI server, make sure -SNAPSHOT is appended, as it is a nightly build.
     // When building normally, or for a release, no suffix is desired.

--- a/plastic/build.gradle
+++ b/plastic/build.gradle
@@ -2,7 +2,7 @@ description = "High-level runtime transformations of Java classes"
 
 dependencies {
     compile "org.slf4j:slf4j-api:${versions.slf4j}"
-
+    compile "net.bytebuddy:byte-buddy:1.6.6"
 }
 
 test { 

--- a/plastic/src/main/java/org/apache/tapestry5/plastic/MethodDescription.java
+++ b/plastic/src/main/java/org/apache/tapestry5/plastic/MethodDescription.java
@@ -110,7 +110,12 @@ public class MethodDescription implements Comparable<MethodDescription>
     public MethodDescription(Method method)
     {
         this(method.getModifiers(), PlasticUtils.toTypeName(method.getReturnType()), method.getName(), PlasticUtils
-                .toTypeNames(method.getParameterTypes()), null, PlasticUtils.toTypeNames(method.getExceptionTypes()));
+                .toTypeNames(method.getParameterTypes()), getGenericSignature(method), PlasticUtils.toTypeNames(method.getExceptionTypes()));
+    }
+
+    private static String getGenericSignature(Method method)
+    {
+        return new net.bytebuddy.description.method.MethodDescription.ForLoadedMethod(method).getGenericSignature();
     }
 
     @Override

--- a/plastic/src/test/groovy/org/apache/tapestry5/plastic/MethodIntroduction.groovy
+++ b/plastic/src/test/groovy/org/apache/tapestry5/plastic/MethodIntroduction.groovy
@@ -1,5 +1,6 @@
 package org.apache.tapestry5.plastic
 
+import testsubjects.BaseClass
 import testsubjects.ChildClass
 
 class MethodIntroduction extends AbstractPlasticSpecification {
@@ -138,5 +139,17 @@ class MethodIntroduction extends AbstractPlasticSpecification {
         present == true
     }
 
+    def "introduce method override with generic parameters and return types"() {
+
+        setup:
+
+        def o = instanceWithIntroducedMethod(new MethodDescription(BaseClass.getMethod("genericParametersAndReturnTypeMethod", Long.class, List.class)), true)
+
+        expect:
+
+        "java.util.Map<java.lang.Long, java.util.List<java.lang.String>>" == o.class.getMethod("genericParametersAndReturnTypeMethod", Long.class, List.class).genericReturnType.typeName
+        "java.lang.Long" == o.class.getMethod("genericParametersAndReturnTypeMethod", Long.class, List.class).genericParameterTypes[0].typeName
+        "java.util.List<java.lang.String>" == o.class.getMethod("genericParametersAndReturnTypeMethod", Long.class, List.class).genericParameterTypes[1].typeName
+    }
 }
 

--- a/plastic/src/test/java/testsubjects/BaseClass.java
+++ b/plastic/src/test/java/testsubjects/BaseClass.java
@@ -1,5 +1,9 @@
 package testsubjects;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 public class BaseClass
 {
     public void voidMethod()
@@ -14,5 +18,11 @@ public class BaseClass
     public String objectMethod(String input)
     {
         return input;
+    }
+
+    public Map<Long, List<String>> genericParametersAndReturnTypeMethod(Long key, List<String> aList) {
+        HashMap<Long, List<String>> map = new HashMap<Long, List<String>>();
+        map.put(key, aList);
+        return map;
     }
 }


### PR DESCRIPTION
The exact return and parameter types are useful if someone does parameter introspection.

The problem we had was when using resteasy with resteasy-jackson-provider and registering proxies to the resteasy Application.

This worked fine in T5.3 but is broken in T5.4.