### PR TITLE
When a non proxied object is beeing eager loaded registry has to inst…

### DIFF
--- a/tapestry-ioc/src/test/groovy/ioc/specs/EagerLoadSpec.groovy
+++ b/tapestry-ioc/src/test/groovy/ioc/specs/EagerLoadSpec.groovy
@@ -7,7 +7,9 @@ class EagerLoadSpec extends AbstractRegistrySpecification {
   def "proxied service does eager load"() {
     expect:
 
-    EagerProxyReloadModule.eagerLoadServiceDidLoad == false
+    EagerProxyReloadModule.eagerLoadService1DidLoad == false
+    EagerProxyReloadModule.nonProxyEagerLoadServiceDidLoad == false
+    EagerProxyReloadModule.eagerLoadService2DidLoad == false
 
     when:
 
@@ -17,6 +19,8 @@ class EagerLoadSpec extends AbstractRegistrySpecification {
 
     then:
 
-    EagerProxyReloadModule.eagerLoadServiceDidLoad == true
+    EagerProxyReloadModule.eagerLoadService1DidLoad == true
+    EagerProxyReloadModule.nonProxyEagerLoadServiceDidLoad == true
+    EagerProxyReloadModule.eagerLoadService2DidLoad == true
   }
 }

--- a/tapestry-ioc/src/test/java/org/apache/tapestry5/ioc/test/EagerLoadService1.java
+++ b/tapestry-ioc/src/test/java/org/apache/tapestry5/ioc/test/EagerLoadService1.java
@@ -1,0 +1,20 @@
+// Copyright 2010 The Apache Software Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.apache.tapestry5.ioc.test;
+
+public interface EagerLoadService1
+{
+
+}

--- a/tapestry-ioc/src/test/java/org/apache/tapestry5/ioc/test/EagerLoadService1Impl.java
+++ b/tapestry-ioc/src/test/java/org/apache/tapestry5/ioc/test/EagerLoadService1Impl.java
@@ -14,19 +14,13 @@
 
 package org.apache.tapestry5.ioc.test;
 
-import org.apache.tapestry5.ioc.ServiceBinder;
+import org.apache.tapestry5.ioc.annotations.EagerLoad;
 
-//@ImportModule(EagerProxy2ReloadModule.class)
-public class EagerProxyReloadModule
+@EagerLoad
+public class EagerLoadService1Impl implements EagerLoadService1
 {
-    public static boolean eagerLoadService1DidLoad;
-    public static boolean nonProxyEagerLoadServiceDidLoad;
-    public static boolean eagerLoadService2DidLoad;
-
-    public static void bind(ServiceBinder binder)
+    public EagerLoadService1Impl()
     {
-        binder.bind(EagerLoadService1.class, EagerLoadService1Impl.class);
-        binder.bind(NonProxiedEagerLoadService.class).eagerLoad();
-        binder.bind(EagerLoadService2.class, EagerLoadService2Impl.class).eagerLoad();
+        EagerProxyReloadModule.eagerLoadService1DidLoad = true;
     }
 }

--- a/tapestry-ioc/src/test/java/org/apache/tapestry5/ioc/test/EagerLoadService2.java
+++ b/tapestry-ioc/src/test/java/org/apache/tapestry5/ioc/test/EagerLoadService2.java
@@ -14,7 +14,7 @@
 
 package org.apache.tapestry5.ioc.test;
 
-public interface EagerLoadService
+public interface EagerLoadService2
 {
 
 }

--- a/tapestry-ioc/src/test/java/org/apache/tapestry5/ioc/test/EagerLoadService2Impl.java
+++ b/tapestry-ioc/src/test/java/org/apache/tapestry5/ioc/test/EagerLoadService2Impl.java
@@ -14,13 +14,11 @@
 
 package org.apache.tapestry5.ioc.test;
 
-import org.apache.tapestry5.ioc.annotations.EagerLoad;
 
-@EagerLoad
-public class EagerLoadServiceImpl implements EagerLoadService
+public class EagerLoadService2Impl implements EagerLoadService2
 {
-    public EagerLoadServiceImpl()
+    public EagerLoadService2Impl()
     {
-        EagerProxyReloadModule.eagerLoadServiceDidLoad = true;
+        EagerProxyReloadModule.eagerLoadService2DidLoad = true;
     }
 }

--- a/tapestry-ioc/src/test/java/org/apache/tapestry5/ioc/test/NonProxiedEagerLoadService.java
+++ b/tapestry-ioc/src/test/java/org/apache/tapestry5/ioc/test/NonProxiedEagerLoadService.java
@@ -1,0 +1,7 @@
+package org.apache.tapestry5.ioc.test;
+
+public class NonProxiedEagerLoadService {
+    public NonProxiedEagerLoadService(EagerLoadService2 service2) {
+        EagerProxyReloadModule.nonProxyEagerLoadServiceDidLoad = true;
+    }
+}


### PR DESCRIPTION
…antiate all its constructor parameters.

If one of these parameters is an eager loaded services (Not yet loaded) registry will create a proxy for it.
Because the proxy is created, that eager load service will not be eager loaded since its already registered as a realized service.

These issue is related with the following

1. https://dev.tapestry.apache.narkive.com/m806StSk/strange-behavour-of-eagerload
2. https://issues.apache.org/jira/browse/TAPESTRY-2267.