### PR TITLE
TAP5-2741: Update to Jakarta EE 9

### DIFF
--- a/beanmodel/build.gradle
+++ b/beanmodel/build.gradle
@@ -1,10 +1,12 @@
+plugins {
+	id 'tapestry.java'
+	id 'antlr'
+}
+
 import org.gradle.plugins.ide.idea.model.*
 import t5build.*
 
 description = "Fast class property discovery, reading and writing library based on bytecode generation. Extracted from Apache Tapestry, but not dependent on the Web framework (tapestry-core) nor the IoC one (tapestry-ioc)."
-
-//apply plugin: JavaPlugin
-apply plugin: 'antlr'
 
 buildDir = 'target/gradle-build'
 

--- a/build.gradle
+++ b/build.gradle
@@ -86,17 +86,6 @@ allprojects {
     apply plugin: "eclipse"
     apply plugin: "idea"
 
-    repositories {
-        mavenLocal()
-        mavenCentral()
-
-        // All things JBoss/Hibernate
-        maven {
-            name "JBoss"
-            url "https://repository.jboss.org/nexus/content/repositories/releases/"
-        }
-    }
-
     configurations {
         // Non-code artifacts, such as sources JARs and zipped JavaDocs
         meta
@@ -137,6 +126,8 @@ String jdkVersion = System.properties['java.version']
 def jdkMajorVersion = jdkVersion.substring(0, jdkVersion.indexOf(".")) // 1, 9, 10...
 
 subprojects {
+	
+	if (!project.name.equals('platform')) {
     
     def specifyMaxPermSize = jdkVersion ==~ /1\.[67].+/
 
@@ -146,83 +137,24 @@ subprojects {
         provided
     }
 
-    apply plugin: "java"
-    apply plugin: "java-library"
+//    apply plugin: "java"
+//    apply plugin: "java-library"
     apply plugin: "groovy" // mostly for testing
-
-    apply plugin: "project-report"
-    apply plugin: "jacoco"
+//    apply plugin: "project-report"
     apply plugin: "base"
     
-    jacoco {
-        toolVersion = "0.8.7"
-    }
-    
-    sourceCompatibility = "1.8"
-    targetCompatibility = "1.8"
-
-    // See http://jira.codehaus.org/browse/GRADLE-784
-
-    sourceSets {
-        main {
-            compileClasspath += configurations.provided
-        }
-        test {
-            compileClasspath += configurations.provided
-            runtimeClasspath += configurations.provided
-        }
-    }
-
-    idea.module {
-        scopes.PROVIDED.plus += [configurations.provided]
-    }
-
-    eclipse.classpath.plusConfigurations += [configurations.provided]
-
-    dependencies {
-        
-        // https://docs.gradle.org/7.3.3/userguide/upgrading_version_6.html#potential_breaking_changes, 
-        // Table 1. Common configuration upgrades
-        testImplementation "org.spockframework:spock-core:${versions.spock}"
-         
-        testRuntimeOnly "org.slf4j:slf4j-log4j12:${versions.slf4j}"
-    }
-
-    compileTestGroovy {
-        configure(groovyOptions.forkOptions) {
-            memoryMaximumSize = '1g'
-            jvmArgs = ['-Xms512m', '-Xmx1g']
-            if (specifyMaxPermSize){
-              jvmArgs << '-XX:MaxPermSize=512m'
-            }
-        }
-    }
-
     tasks.withType(Test) {
-        useTestNG()
+//        useTestNG()
 
-        options.suites("src/test/conf/testng.xml")
-        if (specifyMaxPermSize){
-          maxHeapSize "400M"
-          jvmArgs("-XX:MaxPermSize=200m")
-        }else{
-          maxHeapSize "600M"
-        }
-    
-        // Needed to have XMLTokenStreamTests.testStreamEncoding() passing on Java 9+
-        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_1_9)) {
-            jvmArgs("--add-opens=java.base/java.nio.charset=ALL-UNNAMED");
-        }
+//        options.suites("src/test/conf/testng.xml")
     
         // Turn off live service reloading
 
         systemProperties["tapestry.service-reloading-enabled"] = "false"
+		
+		
         systemProperties["java.io.tmpdir"] = temporaryDir.absolutePath
 
-        jvmArgs("-Dfile.encoding=UTF-8")
-
-        environment.LANG = 'en_US.UTF-8'
-        
         if (continuousIntegrationBuild) {
           // Travis runs our builds with TERM=dumb and kills it if we don't produce any
           // output for 10 minutes, so we log some task execution progress 
@@ -252,14 +184,13 @@ subprojects {
         		.replaceAll("tapestry5", "tapestry")
         		.replaceAll("tapestry-", "")
         		.replaceAll("-", ""))        		
-        	if (projectDir.getName().equals("tapestry-version-migrator")) {
-        		attributes("Main-Class": "org.apache.tapestry5.versionmigrator.Main")
-        	}
         }
     }
     
     assemble.dependsOn(processResources, compileJava, jar)
 
+	
+	// TODO can we just use java.withSourcesJar() in Gradle 7.4.1? 
     task sourcesJar(type: Jar) {
         dependsOn classes
         classifier "sources"
@@ -358,6 +289,7 @@ subprojects {
         }
 
     }
+	}
 }
 
 subprojects.each { project.evaluationDependsOn(it.name) }
@@ -382,73 +314,76 @@ subprojects {
     }
 }
 
-// Cribbed from https://github.com/hibernate/hibernate-core/blob/master/release/release.gradle#L19
 
-task aggregateJavadoc(type: Javadoc) {
-    dependsOn configurations.javadoc
-    group "Documentation"
-
-    description "Build the aggregated JavaDocs for all modules"
-    maxMemory "512m"
-    destinationDir file("$buildDir/documentation/javadocs")
-
-    def tapestryStylesheet = file("src/javadoc/stylesheet7.css")
-    int thisYear = java.time.Year.now().getValue()
-
-    def allMainSourceSets = subprojects*.sourceSets*.main.flatten()
-    def allMainJavaFiles = allMainSourceSets*.java
-    def allMainJavaSrcDirs = allMainJavaFiles*.srcDirs
-
-    options {
-        splitIndex true
-        linkSource true
-        stylesheetFile tapestryStylesheet
-        windowTitle "Tapestry API - ${project.version}"
-        header "Tapestry API - ${project.version}"
-        docTitle "Tapestry API - ($project.version)"
-        bottom "${project.version} - Copyright &copy; 2003-${thisYear} <a href=\"http://tapestry.apache.org/\">The Apache Software Foundation</a>."
-        use = true // 'use' seems to be a reserved word for the DSL
-        links "https://docs.oracle.com/javase/8/docs/api/"
-        links "https://docs.oracle.com/javaee/7/api/"
-        if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
-            tagletPath Collections.unmodifiableList(new ArrayList<>((Set) configurations.javadoc.files))
-        }
-        //  Uncomment jFlags to debug `./gradlew aggregateJavadoc`
-//        jFlags '-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005'
-        addStringOption '-source-path', files(allMainJavaSrcDirs.flatten()).asPath
-        addStringOption 'source', '8'
-        taglets "org.apache.tapestry5.javadoc.TapestryDocTaglet"
-    }
-
-    exclude "org/apache/tapestry5/internal/plastic/asm/**"
-    exclude "org/apache/tapestry5/internal/webresources/**"
-    exclude "org/apache/tapestry5/webresources/modules/**"
-    
-    source allMainJavaFiles
-
-    classpath += files(allMainSourceSets*.compileClasspath)
-
-    inputs.files allMainJavaSrcDirs
-
-    // As part of generating the documentation, ALSO copy any related files:
-    // Any extra images (Tapestry logo)
-    // Any images stored under src/main/java ... everything but .java, .xdoc and package.html
-
-    doLast {
-        copy {
-            from allMainJavaSrcDirs
-            into aggregateJavadoc.destinationDir
-            exclude "**/*.java"
-            exclude "**/*.xdoc"
-            exclude "**/package.html"
-        }
-
-        copy {
-            from file("src/javadoc/images")
-            into aggregateJavadoc.destinationDir
-        }
-    }
-}
+// Perhaps we can leverage the https://docs.freefair.io/gradle-plugins/current/reference/#_io_freefair_aggregate_javadoc plugin to simplify aggreagted Javadoc generation.
+//
+//// Cribbed from https://github.com/hibernate/hibernate-core/blob/master/release/release.gradle#L19
+//
+//task aggregateJavadoc(type: Javadoc) {
+//    dependsOn configurations.javadoc
+//    group "Documentation"
+//
+//    description "Build the aggregated JavaDocs for all modules"
+//    maxMemory "512m"
+//    destinationDir file("$buildDir/documentation/javadocs")
+//
+//    def tapestryStylesheet = file("src/javadoc/stylesheet7.css")
+//    int thisYear = java.time.Year.now().getValue()
+//
+//    def allMainSourceSets = subprojects*.sourceSets*.main.flatten()
+//    def allMainJavaFiles = allMainSourceSets*.java
+//    def allMainJavaSrcDirs = allMainJavaFiles*.srcDirs
+//
+//    options {
+//        splitIndex true
+//        linkSource true
+//        stylesheetFile tapestryStylesheet
+//        windowTitle "Tapestry API - ${project.version}"
+//        header "Tapestry API - ${project.version}"
+//        docTitle "Tapestry API - ($project.version)"
+//        bottom "${project.version} - Copyright &copy; 2003-${thisYear} <a href=\"http://tapestry.apache.org/\">The Apache Software Foundation</a>."
+//        use = true // 'use' seems to be a reserved word for the DSL
+//        links "https://docs.oracle.com/javase/8/docs/api/"
+//        links "https://docs.oracle.com/javaee/7/api/"
+//        if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
+//            tagletPath Collections.unmodifiableList(new ArrayList<>((Set) configurations.javadoc.files))
+//        }
+//        //  Uncomment jFlags to debug `./gradlew aggregateJavadoc`
+////        jFlags '-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005'
+//        addStringOption '-source-path', files(allMainJavaSrcDirs.flatten()).asPath
+//        addStringOption 'source', '8'
+//        taglets "org.apache.tapestry5.javadoc.TapestryDocTaglet"
+//    }
+//
+//    exclude "org/apache/tapestry5/internal/plastic/asm/**"
+//    exclude "org/apache/tapestry5/internal/webresources/**"
+//    exclude "org/apache/tapestry5/webresources/modules/**"
+//    
+//    source allMainJavaFiles
+//
+//    classpath += files(allMainSourceSets*.compileClasspath)
+//
+//    inputs.files allMainJavaSrcDirs
+//
+//    // As part of generating the documentation, ALSO copy any related files:
+//    // Any extra images (Tapestry logo)
+//    // Any images stored under src/main/java ... everything but .java, .xdoc and package.html
+//
+//    doLast {
+//        copy {
+//            from allMainJavaSrcDirs
+//            into aggregateJavadoc.destinationDir
+//            exclude "**/*.java"
+//            exclude "**/*.xdoc"
+//            exclude "**/package.html"
+//        }
+//
+//        copy {
+//            from file("src/javadoc/images")
+//            into aggregateJavadoc.destinationDir
+//        }
+//    }
+//}
 
 task coffeeScriptDocs(type: Exec) {
     group "Documentation"
@@ -473,14 +408,15 @@ task coffeeScriptDocs(type: Exec) {
 
 
 
-dependencies {
-    if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
-        meta aggregateJavadoc.outputs.files
-    }
-}
+//dependencies {
+//    if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
+//        meta aggregateJavadoc.outputs.files
+//    }
+//}
+
 
 task combinedJacocoReport(type:JacocoReport){
-  def subprojectsToConsider = subprojects.findAll {it.name != 'quickstart' && it.name != 'beanmodel' && it.name != 'commons' && it.name != 'genericsresolver-guava' && it.name != 'tapestry5-annotations' && it.name != 'tapestry-internal-test' && it.name != 'tapestry-runner' && it.name != 'tapestry-test-constants' && it.name != 'tapestry-test-data' && it.name != 'tapestry-ioc-jcache'}
+  def subprojectsToConsider = subprojects.findAll {it.name != 'quickstart' && it.name != 'beanmodel' && it.name != 'commons' && it.name != 'genericsresolver-guava' && it.name != 'tapestry5-annotations' && it.name != 'tapestry-internal-test' && it.name != 'tapestry-runner' && it.name != 'tapestry-test-constants' && it.name != 'tapestry-test-data' && it.name != 'tapestry-ioc-jcache' && it.name != 'platform'}
   dependsOn = subprojectsToConsider.test
   additionalSourceDirs.from(files(subprojectsToConsider.sourceSets.main.allSource.srcDirs))
   sourceDirectories.from(files(subprojectsToConsider.sourceSets.main.allSource.srcDirs))
@@ -508,7 +444,7 @@ task continuousIntegration {
     // tapestry-javadoc doesn't work with Java 8 anymore. That's why it's only added if != 8.
     def dependants = [subprojects.build, 'tapestry-core:testWithPrototype', combinedJacocoReport]
     if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
-        dependants << aggregateJavadoc
+        // dependants << aggregateJavadoc
     }
     dependsOn dependants
     description "Task executed on Jenkins CI server after Git commits"
@@ -536,7 +472,7 @@ task zippedSources(type: Zip) {
 }
 
 task zippedApidoc(type: Zip) {
-    dependsOn aggregateJavadoc
+    // dependsOn aggregateJavadoc
     description "Zip archive of the project's aggregate JavaDoc and CoffeeScript documentation"
     group "Release artifact"
 
@@ -554,7 +490,7 @@ task zippedApidoc(type: Zip) {
         exclude "*.html"
     }
 
-    into "apidocs", { from aggregateJavadoc.outputs.files }
+    // into "apidocs", { from aggregateJavadoc.outputs.files }
 
 
     into "coffeescript", { from coffeeScriptDocs.outputs.files }

--- a/build.gradle
+++ b/build.gradle
@@ -319,7 +319,6 @@ subprojects {
 //
 //// Cribbed from https://github.com/hibernate/hibernate-core/blob/master/release/release.gradle#L19
 //
-<<<<<<< HEAD
 tasks.register('aggregateJavadoc', Javadoc) {
     dependsOn configurations.javadoc
     group "Documentation"
@@ -387,73 +386,6 @@ tasks.register('aggregateJavadoc', Javadoc) {
         }
     }
 }
-=======
-//task aggregateJavadoc(type: Javadoc) {
-//    dependsOn configurations.javadoc
-//    group "Documentation"
-//
-//    description "Build the aggregated JavaDocs for all modules"
-//    maxMemory "512m"
-//    destinationDir file("$buildDir/documentation/javadocs")
-//
-//    def tapestryStylesheet = file("src/javadoc/stylesheet7.css")
-//    int thisYear = java.time.Year.now().getValue()
-//
-//    def allMainSourceSets = subprojects*.sourceSets*.main.flatten()
-//    def allMainJavaFiles = allMainSourceSets*.java
-//    def allMainJavaSrcDirs = allMainJavaFiles*.srcDirs
-//
-//    options {
-//        splitIndex true
-//        linkSource true
-//        stylesheetFile tapestryStylesheet
-//        windowTitle "Tapestry API - ${project.version}"
-//        header "Tapestry API - ${project.version}"
-//        docTitle "Tapestry API - ($project.version)"
-//        bottom "${project.version} - Copyright &copy; 2003-${thisYear} <a href=\"http://tapestry.apache.org/\">The Apache Software Foundation</a>."
-//        use = true // 'use' seems to be a reserved word for the DSL
-//        links "https://docs.oracle.com/javase/8/docs/api/"
-//        links "https://docs.oracle.com/javaee/7/api/"
-//        if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
-//            tagletPath Collections.unmodifiableList(new ArrayList<>((Set) configurations.javadoc.files))
-//        }
-//        //  Uncomment jFlags to debug `./gradlew aggregateJavadoc`
-////        jFlags '-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005'
-//        addStringOption '-source-path', files(allMainJavaSrcDirs.flatten()).asPath
-//        addStringOption 'source', '8'
-//        taglets "org.apache.tapestry5.javadoc.TapestryDocTaglet"
-//    }
-//
-//    exclude "org/apache/tapestry5/internal/plastic/asm/**"
-//    exclude "org/apache/tapestry5/internal/webresources/**"
-//    exclude "org/apache/tapestry5/webresources/modules/**"
-//    
-//    source allMainJavaFiles
-//
-//    classpath += files(allMainSourceSets*.compileClasspath)
-//
-//    inputs.files allMainJavaSrcDirs
-//
-//    // As part of generating the documentation, ALSO copy any related files:
-//    // Any extra images (Tapestry logo)
-//    // Any images stored under src/main/java ... everything but .java, .xdoc and package.html
-//
-//    doLast {
-//        copy {
-//            from allMainJavaSrcDirs
-//            into aggregateJavadoc.destinationDir
-//            exclude "**/*.java"
-//            exclude "**/*.xdoc"
-//            exclude "**/package.html"
-//        }
-//
-//        copy {
-//            from file("src/javadoc/images")
-//            into aggregateJavadoc.destinationDir
-//        }
-//    }
-//}
->>>>>>> branch 'TAP5-2741' of git@github.com:apache/tapestry-5.git
 
 task coffeeScriptDocs(type: Exec) {
     group "Documentation"

--- a/build.gradle
+++ b/build.gradle
@@ -319,71 +319,73 @@ subprojects {
 //
 //// Cribbed from https://github.com/hibernate/hibernate-core/blob/master/release/release.gradle#L19
 //
-//task aggregateJavadoc(type: Javadoc) {
-//    dependsOn configurations.javadoc
-//    group "Documentation"
-//
-//    description "Build the aggregated JavaDocs for all modules"
-//    maxMemory "512m"
-//    destinationDir file("$buildDir/documentation/javadocs")
-//
-//    def tapestryStylesheet = file("src/javadoc/stylesheet7.css")
-//    int thisYear = java.time.Year.now().getValue()
-//
+tasks.register('aggregateJavadoc', Javadoc) {
+    dependsOn configurations.javadoc
+    group "Documentation"
+
+    description "Build the aggregated JavaDocs for all modules"
+    maxMemory "512m"
+    destinationDir file("$buildDir/documentation/javadocs")
+
+    def tapestryStylesheet = file("src/javadoc/stylesheet7.css")
+    int thisYear = java.time.Year.now().getValue()
+
 //    def allMainSourceSets = subprojects*.sourceSets*.main.flatten()
-//    def allMainJavaFiles = allMainSourceSets*.java
-//    def allMainJavaSrcDirs = allMainJavaFiles*.srcDirs
-//
-//    options {
-//        splitIndex true
-//        linkSource true
-//        stylesheetFile tapestryStylesheet
-//        windowTitle "Tapestry API - ${project.version}"
-//        header "Tapestry API - ${project.version}"
-//        docTitle "Tapestry API - ($project.version)"
-//        bottom "${project.version} - Copyright &copy; 2003-${thisYear} <a href=\"http://tapestry.apache.org/\">The Apache Software Foundation</a>."
-//        use = true // 'use' seems to be a reserved word for the DSL
-//        links "https://docs.oracle.com/javase/8/docs/api/"
-//        links "https://docs.oracle.com/javaee/7/api/"
-//        if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
+	def allMainSourceSets = subprojects.findAll { subproject -> subproject.plugins.hasPlugin('tapestry.java') }.sourceSets*.main.flatten()
+    def allMainJavaFiles = allMainSourceSets*.java
+    def allMainJavaSrcDirs = allMainJavaFiles*.srcDirs
+
+    options {
+        splitIndex true
+        linkSource true
+        stylesheetFile tapestryStylesheet
+        windowTitle "Tapestry API - ${project.version}"
+        header "Tapestry API - ${project.version}"
+        docTitle "Tapestry API - ($project.version)"
+        bottom "${project.version} - Copyright &copy; 2003-${thisYear} <a href=\"http://tapestry.apache.org/\">The Apache Software Foundation</a>."
+        use = true // 'use' seems to be a reserved word for the DSL
+        links "https://docs.oracle.com/javase/8/docs/api/"
+        links "https://docs.oracle.com/javaee/7/api/"
+        if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
 //            tagletPath Collections.unmodifiableList(new ArrayList<>((Set) configurations.javadoc.files))
-//        }
-//        //  Uncomment jFlags to debug `./gradlew aggregateJavadoc`
-////        jFlags '-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005'
-//        addStringOption '-source-path', files(allMainJavaSrcDirs.flatten()).asPath
-//        addStringOption 'source', '8'
-//        taglets "org.apache.tapestry5.javadoc.TapestryDocTaglet"
-//    }
-//
-//    exclude "org/apache/tapestry5/internal/plastic/asm/**"
-//    exclude "org/apache/tapestry5/internal/webresources/**"
-//    exclude "org/apache/tapestry5/webresources/modules/**"
-//    
-//    source allMainJavaFiles
-//
-//    classpath += files(allMainSourceSets*.compileClasspath)
-//
-//    inputs.files allMainJavaSrcDirs
-//
-//    // As part of generating the documentation, ALSO copy any related files:
-//    // Any extra images (Tapestry logo)
-//    // Any images stored under src/main/java ... everything but .java, .xdoc and package.html
-//
-//    doLast {
-//        copy {
-//            from allMainJavaSrcDirs
-//            into aggregateJavadoc.destinationDir
-//            exclude "**/*.java"
-//            exclude "**/*.xdoc"
-//            exclude "**/package.html"
-//        }
-//
-//        copy {
-//            from file("src/javadoc/images")
-//            into aggregateJavadoc.destinationDir
-//        }
-//    }
-//}
+			tagletPath (configurations.javadoc.files as File[])
+        }
+        //  Uncomment jFlags to debug `./gradlew aggregateJavadoc`
+//        jFlags '-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005'
+        addStringOption '-source-path', files(allMainJavaSrcDirs.flatten()).asPath
+        addStringOption 'source', '8'
+        taglets "org.apache.tapestry5.javadoc.TapestryDocTaglet"
+    }
+
+    exclude "org/apache/tapestry5/internal/plastic/asm/**"
+    exclude "org/apache/tapestry5/internal/webresources/**"
+    exclude "org/apache/tapestry5/webresources/modules/**"
+    
+    source allMainJavaFiles
+
+    classpath += files(allMainSourceSets*.compileClasspath)
+
+    inputs.files allMainJavaSrcDirs
+
+    // As part of generating the documentation, ALSO copy any related files:
+    // Any extra images (Tapestry logo)
+    // Any images stored under src/main/java ... everything but .java, .xdoc and package.html
+
+    doLast {
+        copy {
+            from allMainJavaSrcDirs
+            into aggregateJavadoc.destinationDir
+            exclude "**/*.java"
+            exclude "**/*.xdoc"
+            exclude "**/package.html"
+        }
+
+        copy {
+            from file("src/javadoc/images")
+            into aggregateJavadoc.destinationDir
+        }
+    }
+}
 
 task coffeeScriptDocs(type: Exec) {
     group "Documentation"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,9 +1,11 @@
-apply plugin: "groovy"
-
-repositories {
-    mavenCentral()
+plugins {
+	id 'groovy'
+	id 'groovy-gradle-plugin'
 }
 
+repositories {
+	mavenCentral()
+}
 
 dependencies {
     implementation ("ro.isdc.wro4j:wro4j-extensions:1.8.0"){

--- a/buildSrc/src/main/groovy/tapestry.base.gradle
+++ b/buildSrc/src/main/groovy/tapestry.base.gradle
@@ -1,0 +1,19 @@
+/**
+ * This is a Gradle Convention Plugin serving to share basic build logic between all Tapestry subprojects.
+ * See https://docs.gradle.org/7.4.1/userguide/sharing_build_logic_between_subprojects.html#sec:convention_plugins
+ *
+ * It's written as a script plugin (as opposed to a binary plugin).
+ * See https://docs.gradle.org/7.4.1/userguide/plugins.html#sec:types_of_plugins
+ */
+plugins {
+	id 'base'
+	id 'eclipse'
+	id 'idea'
+}
+
+group = 'org.apache.tapestry'
+
+configurations {
+	// Non-code artifacts, such as sources JARs and zipped JavaDocs
+	meta
+}

--- a/buildSrc/src/main/groovy/tapestry.jakarta-ee-9.gradle
+++ b/buildSrc/src/main/groovy/tapestry.jakarta-ee-9.gradle
@@ -1,0 +1,57 @@
+plugins {
+	id 'tapestry.java'
+	id 'java-library-distribution'
+	id 'maven-publish'
+}
+
+sourceSets {
+	jakarta {
+		java {
+			srcDir 'build/generated/sources/jakarta/java/main'
+		}
+	}
+}
+
+java {
+	registerFeature('javax') {
+		usingSourceSet(sourceSets.main)
+		capability('org.apache.tapestry', 'servlet-api', '3.0.1')
+	}
+	registerFeature('jakarta') {
+		usingSourceSet(sourceSets.jakarta)
+		capability('org.apache.tapestry', 'servlet-api', '5.0.0')
+	}
+}
+
+dependencies {
+	javaxApi 'javax.servlet:javax.servlet-api:3.0.1'
+	jakartaApi ('jakarta.servlet:jakarta.servlet-api:5.0.0') {
+		because 'this is the first version to support the jakarta namespace'
+	}
+}
+
+tasks.register('generateJakartaSources', Copy) {
+	from 'src/main/java'
+	into 'build/generated/sources/jakarta/java/main'
+	filter {
+	  line -> line.replace("javax", "jakarta")
+	}
+}
+
+compileJakartaJava.configure {
+	dependsOn generateJakartaSources
+}
+
+publishing {
+	publications {
+		myLibrary(MavenPublication) {
+			from components.java
+		}
+	}
+	repositories {
+		maven {
+			name = 'test'
+			url = layout.buildDirectory.dir("testRepo")
+		}
+	}
+}

--- a/buildSrc/src/main/groovy/tapestry.java.gradle
+++ b/buildSrc/src/main/groovy/tapestry.java.gradle
@@ -1,0 +1,105 @@
+/**
+ * This is a Gradle Convention Plugin serving to share Java-related build logic between the various Tapestry subprojects.
+ * See https://docs.gradle.org/7.4.1/userguide/sharing_build_logic_between_subprojects.html#sec:convention_plugins
+ * 
+ * It's written as a script plugin (as opposed to a binary plugin).
+ * See https://docs.gradle.org/7.4.1/userguide/plugins.html#sec:types_of_plugins
+ */
+plugins {
+	id 'tapestry.base'
+	id 'java-library' // makes features of 'java' plugin implicitly available 
+	id 'groovy' // mostly for testing
+	id 'jvm-test-suite'
+	id 'jacoco'
+	id 'project-report'		
+	// id 'maven-publish'
+}
+
+java {
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(8)
+	}
+}
+
+// See http://jira.codehaus.org/browse/GRADLE-784
+sourceSets {
+	main {
+		compileClasspath += configurations.provided
+	}
+	test {
+		compileClasspath += configurations.provided
+		runtimeClasspath += configurations.provided
+	}
+}
+
+idea.module {
+	scopes.PROVIDED.plus += [configurations.provided]
+}
+
+eclipse.classpath.plusConfigurations += [configurations.provided]
+
+dependencies {
+
+	api platform(project(':platform'))
+
+}
+
+String jdkVersion = System.properties['java.version']
+def jdkMajorVersion = jdkVersion.substring(0, jdkVersion.indexOf(".")) // 1, 9, 10...
+def specifyMaxPermSize = jdkVersion ==~ /1\.[67].+/
+		
+compileTestGroovy {
+	configure(groovyOptions.forkOptions) {
+		memoryMaximumSize = '1g'
+		jvmArgs = ['-Xms512m', '-Xmx1g']
+		
+		if (specifyMaxPermSize){
+			jvmArgs << '-XX:MaxPermSize=512m'
+		}
+	}
+}
+
+testing {
+	suites { // a test suite is a collection of JVM-based tests
+		test { // this is the built-in 'test' test suite
+			useTestNG()
+			dependencies {
+				implementation 'org.spockframework:spock-core'
+				runtimeOnly 'org.slf4j:slf4j-log4j12'
+			}
+			targets {
+				all {
+					testTask.configure {
+						
+						// Needed to have XMLTokenStreamTests.testStreamEncoding() passing on Java 9+
+						if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_1_9)) {
+							// TODO actually worked without when compiling with Java 17
+							// jvmArgs("--add-opens=java.base/java.nio.charset=ALL-UNNAMED");
+						}
+						
+						if (specifyMaxPermSize) {
+							maxHeapSize "400M"
+							jvmArgs("-XX:MaxPermSize=200m")
+						} else {
+							maxHeapSize "600M"
+						}
+						
+						jvmArgs("-Dfile.encoding=UTF-8")
+						environment.LANG = 'en_US.UTF-8'
+						
+						// Turn off live service reloading
+						systemProperty 'tapestry.service-reloading-enabled', 'false'
+						systemProperty 'java.io.tmpdir', temporaryDir.absolutePath
+						
+						options.suites("src/test/conf/testng.xml")
+						
+					}
+				}
+			}
+		}
+	}
+}
+
+jacoco {
+	toolVersion = '0.8.7'
+}

--- a/commons/build.gradle
+++ b/commons/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 import org.gradle.plugins.ide.idea.model.*
 import t5build.*
 

--- a/genericsresolver-guava/src/test/java/org/apache/tapestry5/genericsresolverguava/internal/AbstractBeanModelSourceImplTest.java
+++ b/genericsresolver-guava/src/test/java/org/apache/tapestry5/genericsresolverguava/internal/AbstractBeanModelSourceImplTest.java
@@ -519,7 +519,7 @@ public abstract class AbstractBeanModelSourceImplTest extends IOCTestCase
 
      bean.getSimple().setAge(24);
 
-     assertEquals(age.getConduit().get(bean), new Integer(24));
+     assertEquals(age.getConduit().get(bean), Integer.valueOf(24));
 
      verify();
  }

--- a/plastic/build.gradle
+++ b/plastic/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "High-level runtime transformations of Java classes"
 
 dependencies {

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -1,0 +1,35 @@
+plugins {
+       id 'tapestry.base'
+       id 'java-platform'
+       id 'maven-publish'
+}
+
+description = 'Gradle platform project for sharing settings across projects.'
+
+dependencies {
+       constraints {
+               def slf4jVersion = '1.7.25'
+               api "org.slf4j:slf4j-api:${slf4jVersion}"
+               api "org.slf4j:slf4j-log4j12:${slf4jVersion}"
+               api 'javax.servlet:javax.servlet-api:3.0.1'
+       }
+}
+
+javaPlatform {
+       // Allow this platform project to have own dependencies, not only dependency constraints.
+       // This is necessary to have this platform include the constraints from third party platforms, specifically Spock.
+       allowDependencies()
+}
+
+dependencies {
+       api platform("org.spockframework:spock-bom:2.3-groovy-3.0")
+}
+
+publishing {
+    publications {
+        tapestryPlatform(MavenPublication) {
+            from components.javaPlatform
+        }
+    }
+}
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -32,6 +32,10 @@ buildCache {
     }
 }
 
+
+//rootProject.name='tapestry-5'
+include "platform"
+
 include "plastic", "tapestry5-annotations", "tapestry-test", "tapestry-func", "tapestry-ioc", "tapestry-json", "tapestry-http", "tapestry-core"
 include "tapestry-hibernate-core", "tapestry-hibernate", "tapestry-jmx", "tapestry-upload", "tapestry-spring"
 include "tapestry-beanvalidator", "tapestry-jpa", "tapestry-kaptcha"
@@ -47,3 +51,25 @@ include "tapestry-webresources", "tapestry-runner", "tapestry-test-constants"
 include "tapestry-ioc-jcache", "beanmodel", "commons", "genericsresolver-guava", "tapestry-version-migrator"
 // include "tapestry-cdi"
 include "tapestry-spock", "tapestry-openapi-viewer", "tapestry-rest-jackson"
+
+dependencyResolutionManagement {
+
+	// Warn if a project declares its own repository
+	repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+
+	repositories {
+
+		mavenLocal()
+
+		mavenCentral()
+
+        // All things JBoss/Hibernate
+		maven {
+			name "JBoss"
+			url "https://repository.jboss.org/nexus/content/repositories/releases/"
+		}
+
+	}
+
+}
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -39,9 +39,9 @@ include "platform"
 include "plastic", "tapestry5-annotations", "tapestry-test", "tapestry-func", "tapestry-ioc", "tapestry-json", "tapestry-http", "tapestry-core"
 include "tapestry-hibernate-core", "tapestry-hibernate", "tapestry-jmx", "tapestry-upload", "tapestry-spring"
 include "tapestry-beanvalidator", "tapestry-jpa", "tapestry-kaptcha"
-if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
+//if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
     include "tapestry-javadoc"
-}
+//}
 if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
     include "tapestry-latest-java-tests"
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 plugins {
     id 'com.gradle.enterprise' version '3.13.2'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.10'
@@ -34,13 +33,9 @@ buildCache {
 }
 
 
-//rootProject.name='tapestry-5'
-include "platform"
+rootProject.name='tapestry-5'
 
-=======
-//rootProject.name='tapestry-5'
 include "platform"
->>>>>>> branch 'TAP5-2741' of git@github.com:apache/tapestry-5.git
 include "plastic", "tapestry5-annotations", "tapestry-test", "tapestry-func", "tapestry-ioc", "tapestry-json", "tapestry-http", "tapestry-core"
 include "tapestry-hibernate-core", "tapestry-hibernate", "tapestry-jmx", "tapestry-upload", "tapestry-spring"
 include "tapestry-beanvalidator", "tapestry-jpa", "tapestry-kaptcha"

--- a/tapestry-beanvalidator/build.gradle
+++ b/tapestry-beanvalidator/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 import t5build.*
 
 description = "Support for JSR-303 Bean Validation via the Hibernate validator implementation"

--- a/tapestry-beanvalidator/src/test/java/org/apache/tapestry5/beanvalidator/integration/TapestryBeanValidationIntegrationTests.java
+++ b/tapestry-beanvalidator/src/test/java/org/apache/tapestry5/beanvalidator/integration/TapestryBeanValidationIntegrationTests.java
@@ -19,7 +19,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.testng.annotations.Test;
 
-@Test(sequential = true, groups = "integration")
+@Test(singleThreaded = true, groups = "integration")
 @TapestryTestConfiguration(webAppFolder = "src/test/webapp")
 public class TapestryBeanValidationIntegrationTests extends SeleniumTestCase
 {

--- a/tapestry-clojure/build.gradle
+++ b/tapestry-clojure/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "Allows Clojure functions to be injected into Tapestry services and components"
 
 dependencies {

--- a/tapestry-core/build.gradle
+++ b/tapestry-core/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 import org.gradle.plugins.ide.idea.model.*
 import org.apache.tools.ant.filters.ReplaceTokens
 import t5build.*
@@ -75,7 +79,7 @@ compileTestGroovy.dependsOn compileTestJava
 test {
 	// Needed to have XMLTokenStreamTests.testStreamEncoding() passing on Java 9+
     if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_1_9)) {
-        jvmArgs("--add-opens=java.base/java.nio.charset=ALL-UNNAMED");
+        // jvmArgs("--add-opens=java.base/java.nio.charset=ALL-UNNAMED");
     }
 	// TAP5-2722
 	systemProperty 'user.language', 'en'

--- a/tapestry-func/build.gradle
+++ b/tapestry-func/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "Light-weight functional programming for Flows of values"
 
 dependencies {

--- a/tapestry-hibernate-core/build.gradle
+++ b/tapestry-hibernate-core/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "Basic Hibernate services for Tapestry, useable outside of a Tapestry web application"
 
 

--- a/tapestry-hibernate/build.gradle
+++ b/tapestry-hibernate/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "Provides support for simple CRUD applications built on top of Tapestry and Hibernate"
 
 dependencies {

--- a/tapestry-hibernate/src/test/java/org/apache/tapestry5/hibernate/web/integration/TapestryHibernateIntegrationTests.java
+++ b/tapestry-hibernate/src/test/java/org/apache/tapestry5/hibernate/web/integration/TapestryHibernateIntegrationTests.java
@@ -21,7 +21,7 @@ import org.apache.tapestry5.test.TapestryTestConfiguration;
 import org.example.app0.entities.User;
 import org.testng.annotations.Test;
 
-@Test(sequential = true, groups = "integration")
+@Test(singleThreaded = true, groups = "integration")
 @TapestryTestConfiguration(webAppFolder = "src/test/webapp")
 public class TapestryHibernateIntegrationTests extends SeleniumTestCase
 {

--- a/tapestry-http/build.gradle
+++ b/tapestry-http/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 import org.gradle.plugins.ide.idea.model.*
 import org.apache.tools.ant.filters.ReplaceTokens
 import t5build.*

--- a/tapestry-internal-test/build.gradle
+++ b/tapestry-internal-test/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "Internal utilties used to assist with testing; not intended for outside use"
 
 dependencies {

--- a/tapestry-ioc-jcache/build.gradle
+++ b/tapestry-ioc-jcache/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 import org.gradle.plugins.ide.idea.model.*
 import t5build.*
 

--- a/tapestry-ioc-junit/build.gradle
+++ b/tapestry-ioc-junit/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "Utilities for junit testing a tapestry-ioc application"
 
 dependencies {

--- a/tapestry-ioc/build.gradle
+++ b/tapestry-ioc/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "A code-centric, high-performance, simple Inversion of Control container"
 
 dependencies {

--- a/tapestry-javadoc/build.gradle
+++ b/tapestry-javadoc/build.gradle
@@ -1,4 +1,15 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "JavaDoc Plugin for Tapestry that generates component reference documentation for component classes"
+
+java {
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(11)
+	}
+}
+
 
 dependencies {
   implementation project(':tapestry-core')

--- a/tapestry-javadoc/src/module-info.java
+++ b/tapestry-javadoc/src/module-info.java
@@ -1,0 +1,3 @@
+module javadoc {
+	requires jdk.compile
+}

--- a/tapestry-jmx/build.gradle
+++ b/tapestry-jmx/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "Allows easy exposure of Tapestry Services as JMX MBeans"
 
 dependencies {

--- a/tapestry-jmx/src/test/java/org/apache/tapestry5/jmx/integration/TapestryJmxIntegrationTests.java
+++ b/tapestry-jmx/src/test/java/org/apache/tapestry5/jmx/integration/TapestryJmxIntegrationTests.java
@@ -16,7 +16,7 @@ package org.apache.tapestry5.jmx.integration;
 import org.apache.tapestry5.test.SeleniumTestCase;
 import org.testng.annotations.Test;
 
-@Test(sequential = true, groups = "integration")
+@Test(singleThreaded = true, groups = "integration")
 public class TapestryJmxIntegrationTests extends SeleniumTestCase
 {
     /** TAP5-978 */

--- a/tapestry-jpa/build.gradle
+++ b/tapestry-jpa/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "Provides support for simple CRUD applications built on top of Tapestry and JPA"
 
 dependencies {

--- a/tapestry-json/build.gradle
+++ b/tapestry-json/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "Repackaged, improved (and tested) version of code originally from https://github.com/tdunning/open-json"
 
 dependencies {

--- a/tapestry-kaptcha/build.gradle
+++ b/tapestry-kaptcha/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "Kaptcha user verification support"
 
 dependencies {

--- a/tapestry-latest-java-tests/build.gradle
+++ b/tapestry-latest-java-tests/build.gradle
@@ -1,7 +1,17 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "Test suite for making sure Tapestry runs on latest Java"
 
-sourceCompatibility = "17"
-targetCompatibility = "17"
+//sourceCompatibility = "17"
+//targetCompatibility = "17"
+
+java {
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(17)
+	}
+}
 
 tasks.withType(JavaCompile).each { 
     it.options.compilerArgs.add("--enable-preview")

--- a/tapestry-mongodb/build.gradle
+++ b/tapestry-mongodb/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "Basic MongoDB services for Tapestry, useable outside of a Tapestry web application"
 
 dependencies {

--- a/tapestry-openapi-viewer/build.gradle
+++ b/tapestry-openapi-viewer/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "Embedded OpenAPI (Swagger) viewer for Tapestry, based on Swagger UI"
 
 dependencies {

--- a/tapestry-rest-jackson/build.gradle
+++ b/tapestry-rest-jackson/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "Support for using Jackson Databind with the Tapestry REST support"
 
 dependencies {

--- a/tapestry-runner/build.gradle
+++ b/tapestry-runner/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "Utilities for running a Tapestry application in Jetty or Tomcat as part of test suite."
 
 dependencies {

--- a/tapestry-spock/build.gradle
+++ b/tapestry-spock/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "Provides support Tapestry injections in Spock specifications"
 
 dependencies {
@@ -9,6 +13,10 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter:${versions.junitJupiter}"
 }
 
-test {
-	useJUnitPlatform()
+testing {
+	suites { // a test suite is a collection of JVM-based tests
+		test { // this is the built-in 'test' test suite
+			useJUnitJupiter()
+		}
+	}
 }

--- a/tapestry-spring/build.gradle
+++ b/tapestry-spring/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "Integration of Tapestry with the Spring Inversion Of Control Container"
 
 dependencies {

--- a/tapestry-test-constants/build.gradle
+++ b/tapestry-test-constants/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+	id 'tapestry.java'
+}

--- a/tapestry-test-data/build.gradle
+++ b/tapestry-test-data/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "Utilities for generating random data used when populating entities"
 
 dependencies {

--- a/tapestry-test/build.gradle
+++ b/tapestry-test/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "[Deprecated] Utilities for integration testing of Tapestry applications using Selenium"
 
 dependencies {

--- a/tapestry-upload/build.gradle
+++ b/tapestry-upload/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "File Upload component, with supporting services"
 
 dependencies {

--- a/tapestry-version-migrator/build.gradle
+++ b/tapestry-version-migrator/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "Tool to help migrate source code using Tapestry from one version to another. Initially built for 5.7.0"
 
 dependencies {

--- a/tapestry-webresources/build.gradle
+++ b/tapestry-webresources/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "Integration with WRO4J to perform runtime CoffeeScript compilation, JavaScript minimization, and more."
 
 //configurations {

--- a/tapestry5-annotations/build.gradle
+++ b/tapestry5-annotations/build.gradle
@@ -1,1 +1,5 @@
+plugins {
+	id 'tapestry.java'
+}
+
 description = "Annotations used with Tapestry, Tapestry-IoC and BeanModel applications"


### PR DESCRIPTION
This is going to be a marathon, not a sprint. This first commit is not yet concerned with any of the Jakarta EE stuff. Actually, it's only about breaking up the build logic some more. A more broken-down build logic will hopefully make it easier to accommodate different JDK versions for building and also make it easier to produce the Jakarta EE variants.
I created this draft PR at this early stage to share my progress with you guys.

I'm aware that even though all tests passed with this commit (locally, at least) I temporarily disabled some steps (Javadoc, Jacoco, and publishing, specifically.)

Looking forward to crossing the finish line after 42195 meters :) Hopefully alive, not dead.