### PR TITLE
Set the rootProject.name of the Gradle build for consistent project naming

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -32,6 +32,8 @@ buildCache {
     }
 }
 
+rootProject.name = "tapestry"
+
 include "plastic", "tapestry5-annotations", "tapestry-test", "tapestry-func", "tapestry-ioc", "tapestry-json", "tapestry-http", "tapestry-core"
 include "tapestry-hibernate-core", "tapestry-hibernate", "tapestry-jmx", "tapestry-upload", "tapestry-spring"
 include "tapestry-beanvalidator", "tapestry-jpa", "tapestry-kaptcha"


### PR DESCRIPTION
This PR sets the Gradle build's rootProject name to `tapestry`. If it is more desirable to set this to `tapestry-5` to match the repo name, let me know and I can amend the PR.

Setting the rootProject name to a static value is a general Gradle best practice. Without this value, the project name will fallback to the name of the folder in which the build executed, which can vary from machine to machine.

Tooling such as Gradle Enterprise uses this project name to associate builds from different projects together. In the absence of this change, you may see dynamic project names, such as [this build](https://ge.apache.org/s/ez6ub7uezkxhg) where the project name is "TAPS-2741". A build scan like this can be associated back to it's Jenkins builds via the included links and [values](https://ge.apache.org/s/ez6ub7uezkxhg/custom-values#L30).