### PR TITLE
Fixed JSONObject to honour equals/hashCode contract

### DIFF
--- a/tapestry-json/src/main/java/org/apache/tapestry5/json/JSONObject.java
+++ b/tapestry-json/src/main/java/org/apache/tapestry5/json/JSONObject.java
@@ -893,6 +893,11 @@ public final class JSONObject extends JSONCollection implements Map<String, Obje
         return nameValuePairs.equals(other.nameValuePairs);
     }
 
+    @Override
+    public int hashCode() {
+        return nameValuePairs.hashCode();
+    }
+
     /**
      * Returns a Map of the keys and values of the JSONObject. The returned map is unmodifiable.
      * Note that changes to the JSONObject will be reflected in the map. In addition, null values in the JSONObject

--- a/tapestry-json/src/test/groovy/json/specs/JSONArraySpec.groovy
+++ b/tapestry-json/src/test/groovy/json/specs/JSONArraySpec.groovy
@@ -265,6 +265,25 @@ class JSONArraySpec extends Specification {
         array1 != array2
     }
 
+    def "array hashCode"() {
+        when:
+
+        def array1 = new JSONArray(1, 2, 3)
+        def array2 = new JSONArray(1, 2, 3)
+
+        then:
+
+        array1.hashCode() == array2.hashCode()
+
+        when:
+
+        array2.put 9, "stuff"
+
+        then:
+
+        array1.hashCode() != array2.hashCode()
+    }
+
     def "pretty print"() {
         def array = new JSONArray("fred", "barney")
 

--- a/tapestry-json/src/test/groovy/json/specs/JSONObjectSpec.groovy
+++ b/tapestry-json/src/test/groovy/json/specs/JSONObjectSpec.groovy
@@ -612,6 +612,27 @@ class JSONObjectSpec extends Specification {
         obj1 != obj2
     }
 
+    def "hashCode() implementation"() {
+        def json = /{ "key" : 99 }/
+
+        when:
+
+        def obj1 = new JSONObject(json)
+        def obj2 = new JSONObject(json)
+
+        then:
+
+        obj1.hashCode() == obj2.hashCode()
+
+        when:
+
+        obj2.put("screw", "the pooch")
+
+        then:
+
+        obj1.hashCode() != obj2.hashCode()
+    }
+
     def "escaped characters in the JSON are parsed correctly"() {
         when:
 


### PR DESCRIPTION
JSONObject had an override for `equals` only but not `hashCode`. So an object could be equal to another one but have a different hash code.

Added tests for both JSONObject and JSONArray. The latter required no change to get the test to pass.