### PR TITLE
Migrate from Gradle Enterprise Gradle Plugin to Develocity Gradle Plugin

### DIFF
--- a/.github/workflows/build-pull-request.yaml
+++ b/.github/workflows/build-pull-request.yaml
@@ -3,6 +3,7 @@ on: pull_request
 
 env:
   MOZ_HEADLESS: true
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
 
 jobs:
   build:
@@ -27,7 +28,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Build with Gradle
         run: ./gradlew -Dci=true --no-daemon --continue build

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,19 +1,18 @@
 plugins {
-    id 'com.gradle.enterprise' version '3.13.2'
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.10'
+    id 'com.gradle.develocity' version '3.17.6'
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'
 }
 
 def isTravisCI = System.getenv('TRAVIS_JOB_ID') != null
 def isJenkins = System.getenv('JENKINS_URL') != null
 def isCI = isTravisCI || isJenkins
 
-gradleEnterprise {
+develocity {
     server = "https://ge.apache.org"
+    projectId = "tapestry"
     buildScan {
-        capture { taskInputFiles = true }
         uploadInBackground = !isCI
-        publishAlways()
-        publishIfAuthenticated()
+        publishing.onlyIf { it.authenticated }
         obfuscation {
             // This obfuscates the IP addresses of the build machine in the build scan.
             // Alternatively, the build scan will provide the hostname for troubleshooting host-specific issues.
@@ -27,7 +26,7 @@ buildCache {
         enabled = !isCI
     }
 
-    remote(gradleEnterprise.buildCache) {
+    remote(develocity.buildCache) {
         enabled = false
     }
 }


### PR DESCRIPTION
This change migrates Tapestry to use the Develocity Gradle Plugin. The existing Gradle Enterprise Gradle Plugin will no longer be supported when ge.apache.org is updated to 2024.3.

These changes will not functionally change how build scans are published to ge.apache.org.