### PR TITLE
Publish build scans to develocity.apache.org

### DIFF
--- a/.github/workflows/build-pull-request.yaml
+++ b/.github/workflows/build-pull-request.yaml
@@ -3,7 +3,7 @@ on: pull_request
 
 env:
   MOZ_HEADLESS: true
-  DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   build:

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.gradle.develocity' version '3.17.6'
+    id 'com.gradle.develocity' version '3.18.2'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,7 +8,7 @@ def isJenkins = System.getenv('JENKINS_URL') != null
 def isCI = isTravisCI || isJenkins
 
 develocity {
-    server = "https://ge.apache.org"
+    server = "https://develocity.apache.org"
     projectId = "tapestry"
     buildScan {
         uploadInBackground = !isCI


### PR DESCRIPTION
This PR migrates the Tapestry project to publish Build Scans to the the new Develocity instance at develocity.apache.org.