### PR TITLE
Fix build - use only apache allowed actions

### DIFF
--- a/.github/workflows/build-pull-request.yaml
+++ b/.github/workflows/build-pull-request.yaml
@@ -15,17 +15,11 @@ jobs:
         java: [ 11, 17 ]
     steps:
       - uses: actions/checkout@v3
+
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
-
-      - name: Setup Geckodriver
-        run: |
-          cd /tmp
-          wget https://github.com/mozilla/geckodriver/releases/download/${{ env.GECKODRIVER_VERSION }}/geckodriver-${{ env.GECKODRIVER_VERSION }}-linux64.tar.gz
-          tar -xvzf geckodriver-${{ env.GECKODRIVER_VERSION }}-linux64.tar.gz
-          sudo mv geckodriver /usr/local/bin/
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/build-pull-request.yaml
+++ b/.github/workflows/build-pull-request.yaml
@@ -4,7 +4,6 @@ on: pull_request
 env:
   MOZ_HEADLESS: true
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
-  GECKODRIVER_VERSION: v0.36.0
 
 jobs:
   build:

--- a/.github/workflows/build-pull-request.yaml
+++ b/.github/workflows/build-pull-request.yaml
@@ -13,15 +13,15 @@ jobs:
       matrix:
         java: [ 11, 17 ]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # 6.0.2
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654   # 5.2.0
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e   # 6.1.0
 
       - name: Build with Gradle
         run: ./gradlew -Dci=true --no-daemon --continue build

--- a/.github/workflows/build-pull-request.yaml
+++ b/.github/workflows/build-pull-request.yaml
@@ -13,15 +13,15 @@ jobs:
       matrix:
         java: [ 11, 17 ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build with Gradle
         run: ./gradlew -Dci=true --no-daemon --continue build

--- a/.github/workflows/build-pull-request.yaml
+++ b/.github/workflows/build-pull-request.yaml
@@ -4,6 +4,7 @@ on: pull_request
 env:
   MOZ_HEADLESS: true
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+  GECKODRIVER_VERSION: v0.36.0
 
 jobs:
   build:
@@ -19,13 +20,12 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.java }}
 
-      - name: Setup Firefox
-        uses: browser-actions/setup-firefox@v1
-
-      - name: Setup GeckoDriver
-        uses: browser-actions/setup-geckodriver@latest
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Geckodriver
+        run: |
+          cd /tmp
+          wget https://github.com/mozilla/geckodriver/releases/download/${{ env.GECKODRIVER_VERSION }}/geckodriver-${{ env.GECKODRIVER_VERSION }}-linux64.tar.gz
+          tar -xvzf geckodriver-${{ env.GECKODRIVER_VERSION }}-linux64.tar.gz
+          sudo mv geckodriver /usr/local/bin/
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4


### PR DESCRIPTION
Firefox is already installed in ubuntu-latest so we just have to install the geckodriver

This will remove the dependency on browser-actions which are not in the allowlist. See https://github.com/apache/infrastructure-actions/pull/813